### PR TITLE
- browser_action: remove window-type filter on chrome.tabs.query lookup.

### DIFF
--- a/ext/src/bg/background.js
+++ b/ext/src/bg/background.js
@@ -67,7 +67,7 @@ var settings = {
     'pass_to_clipboard': true,
     'auto_submit_username': false,
     'auto_submit_pass': false,
-    'max_alg_version': 3
+    'max_alg_version': 3,
 };
 
 var _masterkey;
@@ -180,7 +180,8 @@ function store_get(keys) {
         'max_alg_version',
         'pass_store',
         'auto_submit_pass',
-        'auto_submit_username'];
+        'auto_submit_username',
+    ];
     let k2 = []; k2.push.apply(k2, keys); k2.push.apply(k2, setting_keys);
     k2 = [...new Set(k2)];
     let p1 = promised_storage_get(true, k2);

--- a/ext/src/browser_action/browser_action.js
+++ b/ext/src/browser_action/browser_action.js
@@ -291,8 +291,15 @@ function popup(session_store_) {
 }
 
 window.addEventListener('load', function () {
-    chrome.extension.getBackgroundPage().store_get(
-            ['sites', 'username', 'masterkey', 'key_id', 'max_alg_version', 'defaulttype', 'pass_to_clipboard'])
+    chrome.extension.getBackgroundPage().store_get([
+        'sites',
+        'username',
+        'masterkey',
+        'key_id',
+        'max_alg_version',
+        'defaulttype',
+        'pass_to_clipboard',
+    ])
     .then(data => {
         if (data.pwgw_failure) {
             let e = ui.user_warn("System password vault failed! ");

--- a/ext/src/browser_action/browser_action.js
+++ b/ext/src/browser_action/browser_action.js
@@ -129,7 +129,7 @@ let ui = {
 
 function get_active_tab_url() {
     var ret = new Promise(function(resolve, fail){
-        chrome.tabs.query({active:true,windowType:"normal",currentWindow:true}, function(tabres){
+        chrome.tabs.query({active:true,currentWindow:true}, function(tabres){
         if (tabres.length !== 1) {
             ui.user_warn("Error: bug in tab selector");
             console.log(tabres);

--- a/ext/src/options/globaloptions.js
+++ b/ext/src/options/globaloptions.js
@@ -19,8 +19,14 @@ document.querySelector('#auto_submit_username').addEventListener('change', funct
 });
 
 window.addEventListener('load', function() {
-    chrome.extension.getBackgroundPage().store_get(
-        ['defaulttype','passwdtimeout', 'pass_to_clipboard', 'pass_store', 'auto_submit_pass', 'auto_submit_username'])
+    chrome.extension.getBackgroundPage().store_get([
+        'defaulttype',
+        'passwdtimeout',
+        'pass_to_clipboard',
+        'pass_store',
+        'auto_submit_pass',
+        'auto_submit_username',
+    ])
     .then(data => {
         document.querySelector('#passwdtype').value = data.defaulttype;
         document.querySelector('#passwdtimeout').value = data.passwdtimeout;

--- a/ext/src/options/options.js
+++ b/ext/src/options/options.js
@@ -91,7 +91,12 @@ function stored_sites_table_update(stored_sites) {
 }
 
 window.addEventListener('load', function() {
-    chrome.extension.getBackgroundPage().store_get(['sites', 'username', 'max_alg_version', 'key_id'])
+    chrome.extension.getBackgroundPage().store_get([
+        'sites',
+        'username',
+        'max_alg_version',
+        'key_id',
+    ])
     .then(data => {
         stored_sites = data.sites;
         username = data.username;


### PR DESCRIPTION
Chrome 45 added a new window type, 'app' - used when a website is set up as a pseudo-PWA.  
This breaks masterpassword when using a pseudo-PWA.  

Since there is no way to specify filtering on 'window' || 'app', the filter was removed completely.  
I believe this is more succinct than firing one chrome.tabs.query for window, then trying app if the former fails.