### PR TITLE
Upgrade site detection with new configurable/future proof design.  

### DIFF
--- a/ext/src/bg/background.js
+++ b/ext/src/bg/background.js
@@ -67,7 +67,7 @@ var settings = {
     'pass_to_clipboard': true,
     'auto_submit_username': false,
     'auto_submit_pass': false,
-    'max_alg_version': 3
+    'max_alg_version': 3,
 };
 
 var _masterkey;
@@ -180,7 +180,8 @@ function store_get(keys) {
         'max_alg_version',
         'pass_store',
         'auto_submit_pass',
-        'auto_submit_username'];
+        'auto_submit_username',
+    ];
     let k2 = []; k2.push.apply(k2, keys); k2.push.apply(k2, setting_keys);
     k2 = [...new Set(k2)];
     let p1 = promised_storage_get(true, k2);

--- a/ext/src/bg/background.js
+++ b/ext/src/bg/background.js
@@ -68,6 +68,18 @@ var settings = {
     'auto_submit_username': false,
     'auto_submit_pass': false,
     'max_alg_version': 3,
+    'treat_as_same_site': [
+        '.ac.*',
+        '.co.*',
+        '.com.*',
+        '.edu.*',
+        '.geek.*',
+        '.gov.*',
+        '.govt.*',
+        '.net.*',
+        '.org.*',
+        '.school.*',
+    ].join('\n'),
 };
 
 var _masterkey;
@@ -112,6 +124,7 @@ function store_update(d) {
             case 'pass_to_clipboard':
             case 'auto_submit_pass':
             case 'auto_submit_username':
+            case 'treat_as_same_site':
                 settings[k] = syncset[k] = d[k];
                 break;
             case 'username':
@@ -181,7 +194,8 @@ function store_get(keys) {
         'pass_store',
         'auto_submit_pass',
         'auto_submit_username',
-    ];
+        'treat_as_same_site',
+	];
     let k2 = []; k2.push.apply(k2, keys); k2.push.apply(k2, setting_keys);
     k2 = [...new Set(k2)];
     let p1 = promised_storage_get(true, k2);
@@ -204,6 +218,7 @@ function store_get(keys) {
                 case 'pass_to_clipboard':
                 case 'auto_submit_pass':
                 case 'auto_submit_username':
+                case 'treat_as_same_site':
                 case 'max_alg_version':
                     r[k] = settings[k];
                     break;

--- a/ext/src/browser_action/browser_action.js
+++ b/ext/src/browser_action/browser_action.js
@@ -291,8 +291,15 @@ function popup(session_store_) {
 }
 
 window.addEventListener('load', function () {
-    chrome.extension.getBackgroundPage().store_get(
-            ['sites', 'username', 'masterkey', 'key_id', 'max_alg_version', 'defaulttype', 'pass_to_clipboard'])
+    chrome.extension.getBackgroundPage().store_get([
+        'sites',
+        'username',
+        'masterkey',
+        'key_id',
+        'max_alg_version',
+        'defaulttype',
+        'pass_to_clipboard',
+    ])
     .then(data => {
         if (data.pwgw_failure) {
             let e = ui.user_warn("System password vault failed! ");

--- a/ext/src/css/mpwd.css
+++ b/ext/src/css/mpwd.css
@@ -312,6 +312,7 @@ button#siteconfig_show {
 
 .configitem > input,
 .configitem > select,
+.configitem > textarea,
 .configitem > option {
     display: block;
     clear: both;
@@ -325,6 +326,16 @@ button#siteconfig_show {
 }
 .configitem > input[type=checkbox] {
     width: 3em;
+}
+
+.configitem > textarea#treat_as_same_site {
+    width: 300px;
+    height: 300px;
+}
+
+.configitem > p {
+    clear: both;
+    padding-left: 3em;
 }
 
 #stored_sites {

--- a/ext/src/options/globaloptions.js
+++ b/ext/src/options/globaloptions.js
@@ -17,6 +17,9 @@ document.querySelector('#auto_submit_pass').addEventListener('change', function(
 document.querySelector('#auto_submit_username').addEventListener('change', function() {
     chrome.extension.getBackgroundPage().store_update({auto_submit_username: this.checked});
 });
+document.querySelector('#treat_as_same_site').addEventListener('change', function() {
+    chrome.extension.getBackgroundPage().store_update({treat_as_same_site: this.value});
+});
 
 window.addEventListener('load', function() {
     chrome.extension.getBackgroundPage().store_get([
@@ -26,6 +29,7 @@ window.addEventListener('load', function() {
         'pass_store',
         'auto_submit_pass',
         'auto_submit_username',
+        'treat_as_same_site',
     ])
     .then(data => {
         document.querySelector('#passwdtype').value = data.defaulttype;
@@ -34,5 +38,6 @@ window.addEventListener('load', function() {
         document.querySelector('#pass_store').checked = data.pass_store;
         document.querySelector('#auto_submit_pass').checked = data.auto_submit_pass;
         document.querySelector('#auto_submit_username').checked = data.auto_submit_username;
+        document.querySelector('#treat_as_same_site').value = data.treat_as_same_site;
     });
 });

--- a/ext/src/options/globaloptions.js
+++ b/ext/src/options/globaloptions.js
@@ -19,8 +19,14 @@ document.querySelector('#auto_submit_username').addEventListener('change', funct
 });
 
 window.addEventListener('load', function() {
-    chrome.extension.getBackgroundPage().store_get(
-        ['defaulttype','passwdtimeout', 'pass_to_clipboard', 'pass_store', 'auto_submit_pass', 'auto_submit_username'])
+    chrome.extension.getBackgroundPage().store_get([
+        'defaulttype',
+        'passwdtimeout',
+        'pass_to_clipboard',
+        'pass_store',
+        'auto_submit_pass',
+        'auto_submit_username',
+    ])
     .then(data => {
         document.querySelector('#passwdtype').value = data.defaulttype;
         document.querySelector('#passwdtimeout').value = data.passwdtimeout;

--- a/ext/src/options/index.html
+++ b/ext/src/options/index.html
@@ -76,6 +76,17 @@
                 <label for="pass_store">Use OS' password store</label>
                 <input id="pass_store" type="checkbox"/>
             </div>
+            <div class="configitem">
+                <label for="treat_as_same_site">Override as same site</label>
+                <textarea id="treat_as_same_site"></textarea>
+                <p>
+                    Enter overrides above, one per line<br />
+                    lines must start with a . (period)<br />
+                    lines that cannot be parsed are ignored<br />
+                    * is wildcard, will match anything except . (period)<br />
+                    Example: .net.* will treat x.net.nz as a site, instead of ignoring x and using net.nz as the site<br />
+                </p>
+            </div>
         </div>
     </div>
 

--- a/ext/src/options/options.html
+++ b/ext/src/options/options.html
@@ -5,6 +5,10 @@
 <meta charset="UTF-8">
 <style>
 dd { margin-bottom: 0.5em}
+#treat_as_same_site {
+    width: 300px;
+    height: 300px;
+}
 </style>
 </head>
 <body>
@@ -40,6 +44,15 @@ dd { margin-bottom: 0.5em}
             <input id="auto_submit_username" type="checkbox"/>
         <dt><label for="pass_store">Use OS' password store</label><dd>
             <input id="pass_store" type="checkbox"/>
+        <dt><label for="treat_as_same_site">Override as same site</label><dd>
+            <textarea id="treat_as_same_site"></textarea>
+            <p>
+                Enter overrides above, one per line<br />
+                lines must start with a . (period)<br />
+                lines that cannot be parsed are ignored<br />
+                * is wildcard, will match anything except . (period)<br />
+                Example: .net.* will treat x.net.nz as a site, instead of ignoring x and using net.nz as the site<br />
+            </p>
     </dl>
 <script src="globaloptions.js"></script>
 </body>

--- a/ext/src/options/options.js
+++ b/ext/src/options/options.js
@@ -91,7 +91,12 @@ function stored_sites_table_update(stored_sites) {
 }
 
 window.addEventListener('load', function() {
-    chrome.extension.getBackgroundPage().store_get(['sites', 'username', 'max_alg_version', 'key_id'])
+    chrome.extension.getBackgroundPage().store_get([
+        'sites',
+        'username',
+        'max_alg_version',
+        'key_id',
+    ])
     .then(data => {
         stored_sites = data.sites;
         username = data.username;


### PR DESCRIPTION
Add new sync'd option 'treat_as_same_site', which allows configuration of which parts of a domain should be used to identify a site vs it's subdomains or base domains.

Update both options pages to include this, with instructions how to use it. Default to sane values which preserve previopus functionality (hardcoded recognition of .co.* domains)
Rewrite domain matching routine to use new configuration option using regexes.

This patch fixes an issue where countries that use second-level domains (.net.nz, .co.nz, .org.nz, .gov.nz) were misidentified with the second level domain part being used as the site name.
It has sane defaults, but allows configuration so that users can customise for the particulars of their country and other websites that use a two-level base domain system.

This should be fully future proof now.