### PR TITLE
Implement new 'default login names' configuration option, and update …

### DIFF
--- a/ext/src/bg/background.js
+++ b/ext/src/bg/background.js
@@ -67,7 +67,7 @@ var settings = {
     'pass_to_clipboard': true,
     'auto_submit_username': false,
     'auto_submit_pass': false,
-    'max_alg_version': 3
+    'max_alg_version': 3,
 };
 
 var _masterkey;
@@ -180,7 +180,8 @@ function store_get(keys) {
         'max_alg_version',
         'pass_store',
         'auto_submit_pass',
-        'auto_submit_username'];
+        'auto_submit_username',
+    ];
     let k2 = []; k2.push.apply(k2, keys); k2.push.apply(k2, setting_keys);
     k2 = [...new Set(k2)];
     let p1 = promised_storage_get(true, k2);

--- a/ext/src/bg/background.js
+++ b/ext/src/bg/background.js
@@ -68,6 +68,7 @@ var settings = {
     'auto_submit_username': false,
     'auto_submit_pass': false,
     'max_alg_version': 3,
+    'default_loginnames': '',
 };
 
 var _masterkey;
@@ -112,6 +113,7 @@ function store_update(d) {
             case 'pass_to_clipboard':
             case 'auto_submit_pass':
             case 'auto_submit_username':
+            case 'default_loginnames':
                 settings[k] = syncset[k] = d[k];
                 break;
             case 'username':
@@ -181,6 +183,7 @@ function store_get(keys) {
         'pass_store',
         'auto_submit_pass',
         'auto_submit_username',
+        'default_loginnames',
     ];
     let k2 = []; k2.push.apply(k2, keys); k2.push.apply(k2, setting_keys);
     k2 = [...new Set(k2)];
@@ -204,6 +207,7 @@ function store_get(keys) {
                 case 'pass_to_clipboard':
                 case 'auto_submit_pass':
                 case 'auto_submit_username':
+                case 'default_loginnames':
                 case 'max_alg_version':
                     r[k] = settings[k];
                     break;

--- a/ext/src/browser_action/browser_action.html
+++ b/ext/src/browser_action/browser_action.html
@@ -64,8 +64,12 @@
             <div class="text-bigger"><div id="copypass" class="fa fa-copy fa-2 btntool btncopy"></div></div>
         </div>
 
-        <div class="content">
-            <input id="loginname" class="w3-input w3-border-0 w3-small" type="text" placeholder="[user name]"/>
+        <div class="content valign_mid">
+            <div class="dropdown" style="flex:1">
+                <input id="loginname" class="w3-input w3-border-0 w3-small" type="text" placeholder="[user name]"/>
+                <ul id="default_loginnames" style="display:none"></ul>
+            </div>
+            <button id="default_loginnames_dropdown" style="display: none;"><i class="fa fa-chevron-down fa-2" aria-hidden="true"></i></button>
         </div>
 
         <div class="container content">

--- a/ext/src/browser_action/browser_action.js
+++ b/ext/src/browser_action/browser_action.js
@@ -291,8 +291,15 @@ function popup(session_store_) {
 }
 
 window.addEventListener('load', function () {
-    chrome.extension.getBackgroundPage().store_get(
-            ['sites', 'username', 'masterkey', 'key_id', 'max_alg_version', 'defaulttype', 'pass_to_clipboard'])
+    chrome.extension.getBackgroundPage().store_get([
+        'sites',
+        'username',
+        'masterkey',
+        'key_id',
+        'max_alg_version',
+        'defaulttype',
+        'pass_to_clipboard',
+    ])
     .then(data => {
         if (data.pwgw_failure) {
             let e = ui.user_warn("System password vault failed! ");

--- a/ext/src/css/mpwd.css
+++ b/ext/src/css/mpwd.css
@@ -312,6 +312,7 @@ button#siteconfig_show {
 
 .configitem > input,
 .configitem > select,
+.configitem > textarea,
 .configitem > option {
     display: block;
     clear: both;
@@ -325,6 +326,16 @@ button#siteconfig_show {
 }
 .configitem > input[type=checkbox] {
     width: 3em;
+}
+
+.configitem > textarea#default_loginnames {
+    width: 200px;
+    height: 100px;
+}
+
+.configitem > p {
+    clear: both;
+    padding-left: 3em;
 }
 
 #stored_sites {

--- a/ext/src/options/globaloptions.js
+++ b/ext/src/options/globaloptions.js
@@ -17,6 +17,9 @@ document.querySelector('#auto_submit_pass').addEventListener('change', function(
 document.querySelector('#auto_submit_username').addEventListener('change', function() {
     chrome.extension.getBackgroundPage().store_update({auto_submit_username: this.checked});
 });
+document.querySelector('#default_loginnames').addEventListener('change', function() {
+    chrome.extension.getBackgroundPage().store_update({default_loginnames: this.value});
+});
 
 window.addEventListener('load', function() {
     chrome.extension.getBackgroundPage().store_get([
@@ -26,6 +29,7 @@ window.addEventListener('load', function() {
         'pass_store',
         'auto_submit_pass',
         'auto_submit_username',
+        'default_loginnames',
     ])
     .then(data => {
         document.querySelector('#passwdtype').value = data.defaulttype;
@@ -34,5 +38,6 @@ window.addEventListener('load', function() {
         document.querySelector('#pass_store').checked = data.pass_store;
         document.querySelector('#auto_submit_pass').checked = data.auto_submit_pass;
         document.querySelector('#auto_submit_username').checked = data.auto_submit_username;
+        document.querySelector('#default_loginnames').value = data.default_loginnames;
     });
 });

--- a/ext/src/options/globaloptions.js
+++ b/ext/src/options/globaloptions.js
@@ -19,8 +19,14 @@ document.querySelector('#auto_submit_username').addEventListener('change', funct
 });
 
 window.addEventListener('load', function() {
-    chrome.extension.getBackgroundPage().store_get(
-        ['defaulttype','passwdtimeout', 'pass_to_clipboard', 'pass_store', 'auto_submit_pass', 'auto_submit_username'])
+    chrome.extension.getBackgroundPage().store_get([
+        'defaulttype',
+        'passwdtimeout',
+        'pass_to_clipboard',
+        'pass_store',
+        'auto_submit_pass',
+        'auto_submit_username',
+    ])
     .then(data => {
         document.querySelector('#passwdtype').value = data.defaulttype;
         document.querySelector('#passwdtimeout').value = data.passwdtimeout;

--- a/ext/src/options/index.html
+++ b/ext/src/options/index.html
@@ -76,6 +76,11 @@
                 <label for="pass_store">Use OS' password store</label>
                 <input id="pass_store" type="checkbox"/>
             </div>
+            <div class="configitem">
+                <label for="default_loginnames">Default login names (for new sites)</label>
+                <p>One per line</p>
+                <textarea id="default_loginnames"></textarea>
+            </div>
         </div>
     </div>
 

--- a/ext/src/options/options.html
+++ b/ext/src/options/options.html
@@ -5,6 +5,10 @@
 <meta charset="UTF-8">
 <style>
 dd { margin-bottom: 0.5em}
+#default_loginnames {
+    width: 200px;
+    height: 100px;
+}
 </style>
 </head>
 <body>
@@ -40,6 +44,9 @@ dd { margin-bottom: 0.5em}
             <input id="auto_submit_username" type="checkbox"/>
         <dt><label for="pass_store">Use OS' password store</label><dd>
             <input id="pass_store" type="checkbox"/>
+        <dt><label for="default_loginnames">Default login names (for new sites)</label><dd>
+            <p>One per line</p>
+            <textarea id="default_loginnames"></textarea>
     </dl>
 <script src="globaloptions.js"></script>
 </body>

--- a/ext/src/options/options.js
+++ b/ext/src/options/options.js
@@ -91,7 +91,12 @@ function stored_sites_table_update(stored_sites) {
 }
 
 window.addEventListener('load', function() {
-    chrome.extension.getBackgroundPage().store_get(['sites', 'username', 'max_alg_version', 'key_id'])
+    chrome.extension.getBackgroundPage().store_get([
+        'sites',
+        'username',
+        'max_alg_version',
+        'key_id',
+    ])
     .then(data => {
         stored_sites = data.sites;
         username = data.username;


### PR DESCRIPTION
…browser action popup to show a dropdown (cloned from site name dropdown) allowing selection of a default username; but only when the username field is empty (so a new site or one saved with a blank username)

Stop having to enter the same username again and again for each site!